### PR TITLE
Feature/mrm feature qc

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMFeatureFilter.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMFeatureFilter.h
@@ -91,7 +91,7 @@ public:
       @brief Converts a FeatureMap to a qcMLFile::Attachment
 
       @param features FeatureMap to flag or filter
-      @param attachment acML Attachment
+      @param attachment qcML Attachment
 
     */
     void FeatureMapToAttachment(FeatureMap& features, QcMLFile::Attachment& attachment);
@@ -100,7 +100,7 @@ public:
       @brief Calculates the ion ratio between two transitions
 
       @param component_1 component of the numerator
-      @param component_2 component of the denomenator
+      @param component_2 component of the denominator
       @param feature_name name of the feature to calculate the ratio on
        e.g., peak_apex, peak_area
 
@@ -136,7 +136,7 @@ public:
       @param meta_value_l Lower bound (inclusive) for the metaValue range
       @param meta_value_u Upper bound (inclusive) for the metaValue range
 
-      @return True if the metavlue is within the bounds, and False otherwise.
+      @return True if the metaValue is within the bounds, and False otherwise.
     */ 
     bool checkMetaValue(const Feature & component, const String & meta_value_key, const double & meta_value_l, const double & meta_value_u);
     
@@ -159,7 +159,7 @@ private:
 
     /// flag or filter (i.e., remove) features that do not pass the QC
     String flag_or_filter_;
-    /// include the data points for the exctracted ion chromatogram (XIC) in the attachment
+    /// include the data points for the extracted ion chromatogram (XIC) in the attachment
     bool report_xic_;
     /// include the data points for the total ion chromatogram (TIC) in the attachment
     bool report_tic_;
@@ -177,4 +177,5 @@ private:
 }
 
 #endif //  OPENMS_ANALYSIS_OPENSWATH_MRMFEATUREFILTER_H
+
 

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMFeatureQC.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMFeatureQC.h
@@ -72,6 +72,36 @@ public:
     //@}
 
     // Members
+    //
+    /**@brief Quality Controls (QCs) for individual components
+
+      A component is analogous to a transition or subfeature.
+      A component is a transition that corresponds to a single peptide or metabolite
+
+    */
+    struct ComponentQCs
+    {
+      /// name of the component
+      String component_name;
+
+      // Feature members
+      /// retention time lower bound
+      double retention_time_l;
+      /// retention time upper bound
+      double retention_time_u;
+      /// intensity lower bound
+      double intensity_l;
+      /// intensity upper bound
+      double intensity_u;
+      /// overall quality lower bound
+      double overall_quality_l;
+      /// overall quality upper bound
+      double overall_quality_u;
+
+      /// Feature MetaValues
+      std::map<String,std::pair<double,double>> meta_value_qc;
+
+    };
 
     /**@brief Quality Controls (QCs) within a component group
 
@@ -106,36 +136,6 @@ public:
       double ion_ratio_l;
       double ion_ratio_u;
       String ion_ratio_feature_name;
-
-    };
-
-    /**@brief Quality Controls (QCs) for individual components
-
-      A component is analogous to a transition or subfeature.
-      A component is a transition that corresponds to a single peptide or metabolite
-
-    */
-    struct ComponentQCs
-    {
-      /// name of the component
-      String component_name;
-
-      // Feature members
-      /// retention time lower bound
-      double retention_time_l;
-      /// retention time upper bound
-      double retention_time_u;
-      /// intensity lower bound
-      double intensity_l;
-      /// intensity upper bound
-      double intensity_u;
-      /// overall quality lower bound
-      double overall_quality_l;
-      /// overall quality upper bound
-      double overall_quality_u;
-
-      /// Feature MetaValues
-      std::map<String,std::pair<double,double>> meta_value_qc;
 
     };
 

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMFeatureQC.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMFeatureQC.h
@@ -48,9 +48,15 @@ namespace OpenMS
 
   /**
 
-    @brief The MRMFeatureQC is a class to handle the parameters and options for 
-      MRMFeatureFilter. The format is based on the TraML format.
+    @brief The MRMFeatureQC is a class to handle the parameters and options for
+     MRMFeatureFilter.
 
+     The format is based loosely on the TraML format and can be stored and loaded to disk using MRMFeatureQCFile.
+
+     Quality control parameters are available on multiple levels:
+       - the level of a single component (or transition) representing a single transition
+       - the level of a component group (or transition group) representing a single chemical entity
+       - the level of component group pairs (e.g. isotopic pairs) representing multiple chemical entities that may be related by isotopic pairing
   */
   class OPENMS_DLLAPI MRMFeatureQC
   {
@@ -69,14 +75,14 @@ public:
 
     /**@brief Quality Controls (QCs) within a component group
 
-      A component group is analagous to a transition group or feature.
+      A component group is analogous to a transition group or feature.
       A component group includes all transitions that correspond to a given component (i.e., peptide or metabolite)
 
     */
     struct ComponentGroupQCs
     {
       /// name of the component group
-      String component_group_name; 
+      String component_group_name;
 
       // number of transitions and labels
       /// number of heavy ion lower bound
@@ -100,19 +106,19 @@ public:
       double ion_ratio_l;
       double ion_ratio_u;
       String ion_ratio_feature_name;
-        
+
     };
 
     /**@brief Quality Controls (QCs) for individual components
 
-      A component is analagous to a transition or subfeature.
+      A component is analogous to a transition or subfeature.
       A component is a transition that corresponds to a single peptide or metabolite
 
     */
     struct ComponentQCs
     {
       /// name of the component
-      String component_name; 
+      String component_name;
 
       // Feature members
       /// retention time lower bound
@@ -144,16 +150,16 @@ public:
     {
 
       /// name of the component
-      String component_group_name; 
-      /// name of the component to calculate the resolution or retention time 
-      String resolution_pair_name; 
-      /// resolution lower bound 
+      String component_group_name;
+      /// name of the component to calculate the resolution or retention time
+      String resolution_pair_name;
+      /// resolution lower bound
       double resolution_l;
-      /// resolution upper bound 
+      /// resolution upper bound
       double resolution_u;
-      /// retention time lower bound 
+      /// retention time lower bound
       double rt_diff_l;
-      /// retention time upper bound 
+      /// retention time upper bound
       double rt_diff_u;
     };
 

--- a/src/pyOpenMS/pxds/MRMFeatureFilter.pxd
+++ b/src/pyOpenMS/pxds/MRMFeatureFilter.pxd
@@ -1,11 +1,9 @@
-from libcpp.vector cimport vector as libcpp_vector
-from libcpp.map cimport map as libcpp_map
-from String cimport *
+from Types cimport *
 from FeatureMap cimport *
 from MRMFeatureQC cimport *
 from TargetedExperiment cimport *
 
-cdef extern from "<OpenMS/FORMAT/MRMFeatureFilter.h>" namespace "OpenMS":
+cdef extern from "<OpenMS/ANALYSIS/OPENSWATH/MRMFeatureFilter.h>" namespace "OpenMS":
 
     cdef cppclass MRMFeatureFilter:
 

--- a/src/pyOpenMS/pxds/MRMFeatureQC.pxd
+++ b/src/pyOpenMS/pxds/MRMFeatureQC.pxd
@@ -1,12 +1,12 @@
-from libcpp.vector cimport vector as libcpp_vector
-from libcpp.map cimport map as libcpp_map
-from libcpp.pair import pair as libcpp_pair
-from String cimport *
 from Types cimport *
+from String cimport *
 
 cdef extern from "<OpenMS/ANALYSIS/OPENSWATH/MRMFeatureQC.h>" namespace "OpenMS":
 
     cdef cppclass MRMFQC_ComponentGroupQCs "OpenMS::MRMFeatureQC::ComponentGroupQCs":
+        MRMFQC_ComponentGroupQCs()
+        MRMFQC_ComponentGroupQCs(MRMFQC_ComponentGroupQCs &) # no-wrap
+
         String component_group_name
         int n_heavy_l
         int n_heavy_u
@@ -27,6 +27,9 @@ cdef extern from "<OpenMS/ANALYSIS/OPENSWATH/MRMFeatureQC.h>" namespace "OpenMS"
         String ion_ratio_feature_name
 
     cdef cppclass MRMFQC_ComponentQCs "OpenMS::MRMFeatureQC::ComponentQCs":
+        MRMFQC_ComponentQCs()
+        MRMFQC_ComponentQCs(MRMFQC_ComponentQCs &) # no-wrap
+
         String component_name 
         double retention_time_l
         double retention_time_u
@@ -38,6 +41,9 @@ cdef extern from "<OpenMS/ANALYSIS/OPENSWATH/MRMFeatureQC.h>" namespace "OpenMS"
         # currently not supported
 
     cdef cppclass MRMFQC_ComponentGroupPairQCs "OpenMS::MRMFeatureQC::ComponentGroupPairQCs":
+        MRMFQC_ComponentGroupPairQCs()
+        MRMFQC_ComponentGroupPairQCs(MRMFQC_ComponentGroupPairQCs &) # no-wrap
+
         String component_group_name 
         String resolution_pair_name 
         double resolution_l

--- a/src/pyOpenMS/pxds/MRMFeatureQCFile.pxd
+++ b/src/pyOpenMS/pxds/MRMFeatureQCFile.pxd
@@ -9,5 +9,5 @@ cdef extern from "<OpenMS/FORMAT/MRMFeatureQCFile.h>" namespace "OpenMS":
         MRMFeatureQCFile(MRMFeatureQCFile &) nogil except +
 
         void load(String filename, MRMFeatureQC mrmfqc) nogil except +
-        void store(String filename, MRMFeatureQC mrmfqc) nogil except +
+        # void store(String filename, MRMFeatureQC mrmfqc) nogil except +
 

--- a/src/pyOpenMS/pxds/MRMFeatureQCFile.pxd
+++ b/src/pyOpenMS/pxds/MRMFeatureQCFile.pxd
@@ -1,7 +1,7 @@
 from String cimport *
 from MRMFeatureQC cimport *
 
-cdef extern from "<OpenMS/ANALYSIS/OPENSWATH/MRMFeatureQCFile.h>" namespace "OpenMS":
+cdef extern from "<OpenMS/FORMAT/MRMFeatureQCFile.h>" namespace "OpenMS":
 
     cdef cppclass MRMFeatureQCFile:
 
@@ -9,4 +9,5 @@ cdef extern from "<OpenMS/ANALYSIS/OPENSWATH/MRMFeatureQCFile.h>" namespace "Ope
         MRMFeatureQCFile(MRMFeatureQCFile &) nogil except +
 
         void load(String filename, MRMFeatureQC mrmfqc) nogil except +
-        void store(String filename, MRMFeatureQC mrmfqc);
+        void store(String filename, MRMFeatureQC mrmfqc) nogil except +
+


### PR DESCRIPTION
now pyOpenMS compiles, please merge

PS: given that MRMFeatureQCFile::store is not implemented, could you remove it from the header file?